### PR TITLE
Customizable extention, 404 page, check URL for menu item

### DIFF
--- a/index.php
+++ b/index.php
@@ -66,7 +66,7 @@ if ($requestedpage === $blogpagename)
   foreach($pages as $page)
   {
     list($pageheader, $pagecontent, $pagetitle, $pageauthor, $pagedate, $pagenomenu, $pageurl) = getpage($page);
-    echo "<div class=\"article\"><a href=\"". substr($page, 2, strlen($page)-6) . "\">";
+    echo "<div class=\"article\"><a href=\"". substr($page, 2, strlen($page)-(2+strlen($extension))) . "\">";
     echo "<h2 class=\"articletitle\">$pagetitle</h2><div class=\"articleinfo\">by $pageauthor, on $pagedate</div></a>";
     echo (new Parsedown())->text($pagecontent);
     echo "</div>";


### PR DESCRIPTION
There are two new options at the top of the file to allow the user
to specifiy what file extension they wish to use as well as what
404 page they wish to use. The menu items are checked to make sure
that have a non-empty URL. Previously a file could be created with
a TITLE and a blank URL breaking the anchor tag that would be
generated.

I also cleaned up the <?php echos ?> by using the <?= syntax which
is cleaner and more readable.

This also fixes and issue with older PHP versions where empty() can't take a function return as its input value on line 35.
